### PR TITLE
Specify which provider you want to publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Themsaid\MailPreview\MailPreviewServiceProvider::class
 Then publish the config file:
 
 ```
-php artisan vendor:publish
+php artisan vendor:publish --provider="Themsaid\MailPreview\MailPreviewServiceProvider"
 ```
 
 Finally, change `MAIL_DRIVER` to `preview` in your `.env` file:


### PR DESCRIPTION
I've appended the service provider to the vendor:publish line. In my projects i want as few config files as possible. This way you only publish the config for this package, not for other packages where the default config is fine as it is.