### PR TITLE
Update illuminate constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,9 +12,9 @@
     ],
     "require": {
         "php": ">=5.5.9",
-        "illuminate/support": "^5.1",
-        "illuminate/mail": "^5.1",
-        "illuminate/filesystem": "^5.1",
+        "illuminate/support": "5.1.* || 5.2.*",
+        "illuminate/mail": "5.1.* || 5.2.*",
+        "illuminate/filesystem": "5.1.* || 5.2.*",
         "mockery/mockery": "~0.9.2"
     },
     "require-dev": {


### PR DESCRIPTION
Since Laravel [doesn't follow semantic versioning](https://medium.com/@vinkla/laravel-packages-and-semantic-versioning-f62dc5accee5) we wont know if this package will break in version 5.3. The solution is to be more specific with the version constraint. 