### PR TITLE
Added middleware config option for preview route

### DIFF
--- a/src/MailPreviewServiceProvider.php
+++ b/src/MailPreviewServiceProvider.php
@@ -22,7 +22,11 @@ class MailPreviewServiceProvider extends ServiceProvider
 
         if ($this->app['config']['mailpreview.show_link_to_preview']) {
             if (! $this->app->routesAreCached()) {
-                $this->app['router']->group(['middleware' => $this->app['config']['mailpreview.middleware']], function($router) {
+
+                // Check if middleware config option is set correctly
+                $middleware = (is_array($this->app['config']['mailpreview.middleware']) ? $this->app['config']['mailpreview.middleware'] : []);
+
+                $this->app['router']->group(['middleware' => $middleware], function($router) {
                     $router->get('/themsaid/mail-preview', function () {
                         if ($previewPath = $this->app['request']->input('path')) {
                             $content = file_get_contents(storage_path('email-previews/'.$previewPath.'.html'));

--- a/src/MailPreviewServiceProvider.php
+++ b/src/MailPreviewServiceProvider.php
@@ -22,16 +22,18 @@ class MailPreviewServiceProvider extends ServiceProvider
 
         if ($this->app['config']['mailpreview.show_link_to_preview']) {
             if (! $this->app->routesAreCached()) {
-                $this->app['router']->get('/themsaid/mail-preview', function () {
-                    if ($previewPath = $this->app['request']->input('path')) {
-                        $content = file_get_contents(storage_path('email-previews/'.$previewPath.'.html'));
-                    } else {
-                        $lastPreviewName = last(glob(storage_path('email-previews').'/*.html'));
+                $this->app['router']->group(['middleware' => $this->app['config']['mailpreview.middleware']], function($router) {
+                    $router->get('/themsaid/mail-preview', function () {
+                        if ($previewPath = $this->app['request']->input('path')) {
+                            $content = file_get_contents(storage_path('email-previews/'.$previewPath.'.html'));
+                        } else {
+                            $lastPreviewName = last(glob(storage_path('email-previews').'/*.html'));
 
-                        $content = file_get_contents($lastPreviewName);
-                    }
+                            $content = file_get_contents($lastPreviewName);
+                        }
 
-                    return $content;
+                        return $content;
+                    });
                 });
             }
 

--- a/src/config/mailpreview.php
+++ b/src/config/mailpreview.php
@@ -39,4 +39,15 @@ return [
      */
 
     'show_link_to_preview' => true,
+
+    /**
+     * --------------------------------------------------------------------------
+     * Set middleware array for the preview route
+     * --------------------------------------------------------------------------
+     *
+     * Useful for web middleware group in laravel 5.2
+     */
+
+    'middleware' => [
+    ],
 ];


### PR DESCRIPTION
When visiting `/themsaid/mail-preview` route on a laravel 5.2 project I got:

```RuntimeException in Request.php line 852:
Session store not set on request.```

This because I make use of the `web` middleware to load the session etc only on the needed routes.

In this PR I added a config option for middleware array that can be added on the `/themsaid/mail-preview` route if this is needed for the project. Default it is just an empty array.