### PR TITLE
Removed share method

### DIFF
--- a/src/MailProvider.php
+++ b/src/MailProvider.php
@@ -30,7 +30,7 @@ class MailProvider extends MailServiceProvider
      */
     private function registerPreviewSwiftMailer()
     {
-        $this->app['swift.mailer'] = $this->app->share(function ($app) {
+        $this->app->singleton('swift.mailer', function($app) {
             return new Swift_Mailer(
                 new PreviewTransport(
                     $app->make('Illuminate\Filesystem\Filesystem'),


### PR DESCRIPTION
The share method has been remove in Laravel 5.4 and the singleton
method should be used instead.