### PR TITLE
Add support for Laravel 5.5 but not backwards compatible

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,13 +12,13 @@
     ],
     "require": {
         "php": ">=5.5.9",
-        "illuminate/support": "~5.1",
-        "illuminate/mail": "~5.1",
-        "illuminate/filesystem": "~5.1",
+        "illuminate/support": "~5.5",
+        "illuminate/mail": "~5.5",
+        "illuminate/filesystem": "~5.5",
         "mockery/mockery": "~0.9.2"
     },
     "require-dev": {
-        "phpunit/phpunit" : "4.*",
+        "phpunit/phpunit" : "~6.0",
         "orchestra/testbench": "~3.0"
     },
     "autoload": {

--- a/src/PreviewTransport.php
+++ b/src/PreviewTransport.php
@@ -3,7 +3,7 @@
 namespace Themsaid\MailPreview;
 
 use Illuminate\Support\Facades\Session;
-use Swift_Mime_Message;
+use Swift_Mime_SimpleMessage;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Mail\Transport\Transport;
 
@@ -49,7 +49,7 @@ class PreviewTransport extends Transport
     /**
      * {@inheritdoc}
      */
-    public function send(Swift_Mime_Message $message, &$failedRecipients = null)
+    public function send(Swift_Mime_SimpleMessage $message, &$failedRecipients = null)
     {
         $this->beforeSendPerformed($message);
 
@@ -73,27 +73,27 @@ class PreviewTransport extends Transport
     /**
      * Get the path to the email preview file.
      *
-     * @param  \Swift_Mime_Message $message
+     * @param  \Swift_Mime_SimpleMessage $message
      *
      * @return string
      */
-    protected function getPreviewFilePath(Swift_Mime_Message $message)
+    protected function getPreviewFilePath(Swift_Mime_SimpleMessage $message)
     {
         $to = str_replace(['@', '.'], ['_at_', '_'], array_keys($message->getTo())[0]);
 
         $subject = $message->getSubject();
 
-        return $this->previewPath.'/'.str_slug($message->getDate().'_'.$to.'_'.$subject, '_');
+        return $this->previewPath.'/'.str_slug($message->getDate()->getTimestamp().'_'.$to.'_'.$subject, '_');
     }
 
     /**
      * Get the HTML content for the preview file.
      *
-     * @param  \Swift_Mime_Message $message
+     * @param  \Swift_Mime_SimpleMessage $message
      *
      * @return string
      */
-    protected function getHTMLPreviewContent(Swift_Mime_Message $message)
+    protected function getHTMLPreviewContent(Swift_Mime_SimpleMessage $message)
     {
         $messageInfo = $this->getMessageInfo($message);
 
@@ -103,11 +103,11 @@ class PreviewTransport extends Transport
     /**
      * Get the EML content for the preview file.
      *
-     * @param  \Swift_Mime_Message $message
+     * @param  \Swift_Mime_SimpleMessage $message
      *
      * @return string
      */
-    protected function getEMLPreviewContent(Swift_Mime_Message $message)
+    protected function getEMLPreviewContent(Swift_Mime_SimpleMessage $message)
     {
         return $message->toString();
     }
@@ -115,11 +115,11 @@ class PreviewTransport extends Transport
     /**
      * Generate a human readable HTML comment with message info.
      *
-     * @param \Swift_Mime_Message $message
+     * @param \Swift_Mime_SimpleMessage $message
      *
      * @return string
      */
-    private function getMessageInfo(Swift_Mime_Message $message)
+    private function getMessageInfo(Swift_Mime_SimpleMessage $message)
     {
         return sprintf(
             "<!--\nFrom:%s, \nto:%s, \nreply-to:%s, \ncc:%s, \nbcc:%s, \nsubject:%s\n-->\n",

--- a/tests/MailPreviewTest.php
+++ b/tests/MailPreviewTest.php
@@ -61,12 +61,12 @@ class MailPreviewTest extends TestCase
         $files->shouldReceive('files')->once()->with('framework/emails')->andReturn([]);
 
         $files->shouldReceive('put')->with(
-            'framework/emails/'.$message->getDate().'_me_at_example_com_foo_subject.html',
+            'framework/emails/'.$message->getDate()->getTimestamp().'_me_at_example_com_foo_subject.html',
             m::any()
         );
 
         $files->shouldReceive('put')->with(
-            'framework/emails/'.$message->getDate().'_me_at_example_com_foo_subject.eml',
+            'framework/emails/'.$message->getDate()->getTimestamp().'_me_at_example_com_foo_subject.eml',
             $message->toString()
         );
 


### PR DESCRIPTION
Laravel 5.5 is supported in this pull request but is not compatible with older versions. Had to bump Laravel dependencies to ~5.5 as well.

Also - naming of the preview files generated is now converted to a timestamp as the `getDate()` method of the DateTimeImmutable object cannot be echoed to a string anymore. This is now using `getDate()->getTimestamp()` instead.

Another note - PHPUnit tests pass but 3 are marked as "risky" as no assertions were made.