### PR TITLE
Makes getMessageInfo and registerPreviewSwiftMailer protected for extendability

### DIFF
--- a/src/MailProvider.php
+++ b/src/MailProvider.php
@@ -28,7 +28,7 @@ class MailProvider extends MailServiceProvider
      *
      * @return void
      */
-    private function registerPreviewSwiftMailer()
+    protected function registerPreviewSwiftMailer()
     {
         $this->app->singleton('swift.mailer', function($app) {
             return new Swift_Mailer(

--- a/src/PreviewTransport.php
+++ b/src/PreviewTransport.php
@@ -119,7 +119,7 @@ class PreviewTransport extends Transport
      *
      * @return string
      */
-    private function getMessageInfo(Swift_Mime_SimpleMessage $message)
+    protected function getMessageInfo(Swift_Mime_SimpleMessage $message)
     {
         return sprintf(
             "<!--\nFrom:%s, \nto:%s, \nreply-to:%s, \ncc:%s, \nbcc:%s, \nsubject:%s\n-->\n",


### PR DESCRIPTION
I'm currently building a tool for local mail development that leverages some of your mail preview package functionality ( will be fully credited of course ). I'm hoping that we can just change these methods from private to protected so they can be extended.