### PR TITLE
Allow mockery v1 and move to dev deps

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,10 +14,11 @@
         "php": ">=5.5.9",
         "illuminate/support": "~5.5",
         "illuminate/mail": "~5.5",
-        "illuminate/filesystem": "~5.5",
-        "mockery/mockery": "~0.9.2"
+        "illuminate/filesystem": "~5.5"
+
     },
     "require-dev": {
+        "mockery/mockery": "~0.9.2|~1.0.0",
         "phpunit/phpunit" : "~6.0",
         "orchestra/testbench": "~3.0"
     },


### PR DESCRIPTION
Mockery seems only needed for the tests of this package. Let's also allow Mockery v1.