### PR TITLE
Fix issue with EncryptCookies middleware

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,14 +12,14 @@
     ],
     "require": {
         "php": ">=5.5.9",
-        "illuminate/support": "~5.5",
-        "illuminate/mail": "~5.5",
-        "illuminate/filesystem": "~5.5"
+        "illuminate/support": "~5.5||^6.0",
+        "illuminate/mail": "~5.5||^6.0",
+        "illuminate/filesystem": "~5.5||^6.0"
 
     },
     "require-dev": {
-        "mockery/mockery": "~0.9.2 || ~1.0.0",
-        "phpunit/phpunit" : "~6.0 || ~7.0",
+        "mockery/mockery": "~0.9.2||~1.0.0",
+        "phpunit/phpunit" : "~6.0||~7.0||~8.0",
         "orchestra/testbench": "~3.0"
     },
     "autoload": {

--- a/src/MailPreviewMiddleware.php
+++ b/src/MailPreviewMiddleware.php
@@ -61,7 +61,7 @@ class MailPreviewMiddleware
             border:solid 1px #ccc;
             padding: 15px;
             '>
-        An email was just sent: <a href='" . url('/themsaid/mail-preview?path=' . $previewPath) . "'>Preview Sent Email</a>
+        An email was just sent: <a href='".url('/themsaid/mail-preview?path='.$previewPath)."'>Preview Sent Email</a>
         </div>";
 
         $timeout = intval(config('mailpreview.popup_timeout', 8000));
@@ -80,7 +80,7 @@ class MailPreviewMiddleware
         $bodyPosition = strripos($content, '</body>');
 
         if (false !== $bodyPosition) {
-            $content = substr($content, 0, $bodyPosition) . $linkHTML . substr($content, $bodyPosition);
+            $content = substr($content, 0, $bodyPosition).$linkHTML.substr($content, $bodyPosition);
         }
 
         $response->setContent($content);

--- a/src/MailPreviewMiddleware.php
+++ b/src/MailPreviewMiddleware.php
@@ -16,16 +16,24 @@ class MailPreviewMiddleware
      */
     public function handle($request, Closure $next)
     {
-        $response = $next($request);
+        $addLinktoResponse = false;
 
         if (
             $request->hasSession() &&
-            $response instanceOf Response &&
             $previewPath = $request->session()->get('mail_preview_path')
         ) {
-            $this->addLinkToResponse($response, $previewPath);
+            $addLinktoResponse = true;
+        }
 
+        $response = $next($request);
+
+        if (
+            $response instanceof Response &&
+            $addLinktoResponse
+        ) {
             $request->session()->forget('mail_preview_path');
+
+            $this->addLinkToResponse($response, $previewPath);
         }
 
         return $response;
@@ -53,7 +61,7 @@ class MailPreviewMiddleware
             border:solid 1px #ccc;
             padding: 15px;
             '>
-        An email was just sent: <a href='".url('/themsaid/mail-preview?path='.$previewPath)."'>Preview Sent Email</a>
+        An email was just sent: <a href='" . url('/themsaid/mail-preview?path=' . $previewPath) . "'>Preview Sent Email</a>
         </div>";
 
         $timeout = intval(config('mailpreview.popup_timeout', 8000));
@@ -72,7 +80,7 @@ class MailPreviewMiddleware
         $bodyPosition = strripos($content, '</body>');
 
         if (false !== $bodyPosition) {
-            $content = substr($content, 0, $bodyPosition).$linkHTML.substr($content, $bodyPosition);
+            $content = substr($content, 0, $bodyPosition) . $linkHTML . substr($content, $bodyPosition);
         }
 
         $response->setContent($content);

--- a/src/MailPreviewServiceProvider.php
+++ b/src/MailPreviewServiceProvider.php
@@ -2,7 +2,6 @@
 
 namespace Themsaid\MailPreview;
 
-use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Support\ServiceProvider;
 
 class MailPreviewServiceProvider extends ServiceProvider
@@ -15,7 +14,7 @@ class MailPreviewServiceProvider extends ServiceProvider
     public function boot()
     {
         $this->publishes([
-            __DIR__.'/config/mailpreview.php' => config_path('mailpreview.php'),
+            __DIR__ . '/config/mailpreview.php' => config_path('mailpreview.php'),
         ]);
 
         if ($this->app['config']['mail.driver'] != 'preview') {
@@ -23,14 +22,18 @@ class MailPreviewServiceProvider extends ServiceProvider
         }
 
         if ($this->app['config']['mailpreview.show_link_to_preview']) {
-
             $this->app['router']->group(['middleware' => $this->middleware()], function ($router) {
-                $router->get('/themsaid/mail-preview')->uses(MailPreviewController::class.'@preview');
+                $router->get('/themsaid/mail-preview')->uses(MailPreviewController::class . '@preview');
             });
 
-            $this->app[Kernel::class]->pushMiddleware(
-                MailPreviewMiddleware::class
-            );
+            if ($this->app['config']['mailpreview.middleware_groups']) {
+                foreach ($this->app['config']['mailpreview.middleware_groups'] as $groupName) {
+                    $this->app['router']->pushMiddlewareToGroup(
+                        $groupName,
+                        MailPreviewMiddleware::class
+                    );
+                }
+            }
         }
     }
 
@@ -42,7 +45,7 @@ class MailPreviewServiceProvider extends ServiceProvider
     public function register()
     {
         $this->mergeConfigFrom(
-            __DIR__.'/config/mailpreview.php', 'mailpreview'
+            __DIR__ . '/config/mailpreview.php', 'mailpreview'
         );
 
         $this->app->register(MailProvider::class);
@@ -56,7 +59,7 @@ class MailPreviewServiceProvider extends ServiceProvider
     private function middleware()
     {
         return array_merge(
-            (array) $this->app['config']['mailpreview.middleware'],
+            (array)$this->app['config']['mailpreview.middleware'],
             [\Illuminate\Session\Middleware\StartSession::class]
         );
     }

--- a/src/MailPreviewServiceProvider.php
+++ b/src/MailPreviewServiceProvider.php
@@ -14,7 +14,7 @@ class MailPreviewServiceProvider extends ServiceProvider
     public function boot()
     {
         $this->publishes([
-            __DIR__ . '/config/mailpreview.php' => config_path('mailpreview.php'),
+            __DIR__.'/config/mailpreview.php' => config_path('mailpreview.php'),
         ]);
 
         if ($this->app['config']['mail.driver'] != 'preview') {
@@ -23,7 +23,7 @@ class MailPreviewServiceProvider extends ServiceProvider
 
         if ($this->app['config']['mailpreview.show_link_to_preview']) {
             $this->app['router']->group(['middleware' => $this->middleware()], function ($router) {
-                $router->get('/themsaid/mail-preview')->uses(MailPreviewController::class . '@preview');
+                $router->get('/themsaid/mail-preview')->uses(MailPreviewController::class.'@preview');
             });
 
             if ($this->app['config']['mailpreview.middleware_groups']) {
@@ -45,7 +45,7 @@ class MailPreviewServiceProvider extends ServiceProvider
     public function register()
     {
         $this->mergeConfigFrom(
-            __DIR__ . '/config/mailpreview.php', 'mailpreview'
+            __DIR__.'/config/mailpreview.php', 'mailpreview'
         );
 
         $this->app->register(MailProvider::class);
@@ -59,7 +59,7 @@ class MailPreviewServiceProvider extends ServiceProvider
     private function middleware()
     {
         return array_merge(
-            (array)$this->app['config']['mailpreview.middleware'],
+            (array) $this->app['config']['mailpreview.middleware'],
             [\Illuminate\Session\Middleware\StartSession::class]
         );
     }

--- a/src/PreviewTransport.php
+++ b/src/PreviewTransport.php
@@ -3,6 +3,7 @@
 namespace Themsaid\MailPreview;
 
 use Illuminate\Support\Facades\Session;
+use Illuminate\Support\Str;
 use Swift_Mime_SimpleMessage;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Mail\Transport\Transport;
@@ -83,7 +84,7 @@ class PreviewTransport extends Transport
 
         $subject = $message->getSubject();
 
-        return $this->previewPath.'/'.str_slug($message->getDate()->getTimestamp().'_'.$to.'_'.$subject, '_');
+        return $this->previewPath.'/'.Str::slug($message->getDate()->getTimestamp().'_'.$to.'_'.$subject, '_');
     }
 
     /**

--- a/src/config/mailpreview.php
+++ b/src/config/mailpreview.php
@@ -50,6 +50,17 @@ return [
 
     /**
      * --------------------------------------------------------------------------
+     * Middleware group(s)
+     * --------------------------------------------------------------------------
+     *
+     * Most likely you don't have to touch this value, in this array all
+     * middleware groups that you want to use this package with should
+     * be included.
+     */
+    'middleware_groups' => ['web'],
+
+    /**
+     * --------------------------------------------------------------------------
      * Set middleware for the mail preview route
      * --------------------------------------------------------------------------
      *


### PR DESCRIPTION
This issue only occurs when using the `EncryptCookies` middleware.

This fixes the issues that came from the Laravel 5.8 release as described in https://github.com/themsaid/laravel-mail-preview/issues/45.

I think this is a breaking change as the middleware is now pushed to a specific middleware groups instead of using the global middleware stack.