### PR TITLE
Support Laravel 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
 
     },
     "require-dev": {
-        "mockery/mockery": "~0.9.2 || ~1.0.0",
-        "phpunit/phpunit" : "~6.0 || ~7.0",
+        "mockery/mockery": "~0.9.2||~1.0.0",
+        "phpunit/phpunit" : "~6.0||~7.0",
         "orchestra/testbench": "~3.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -12,14 +12,14 @@
     ],
     "require": {
         "php": ">=5.5.9",
-        "illuminate/support": "~5.5",
-        "illuminate/mail": "~5.5",
-        "illuminate/filesystem": "~5.5"
+        "illuminate/support": "~5.5||^6.0",
+        "illuminate/mail": "~5.5||^6.0",
+        "illuminate/filesystem": "~5.5||^6.0"
 
     },
     "require-dev": {
         "mockery/mockery": "~0.9.2||~1.0.0",
-        "phpunit/phpunit" : "~6.0||~7.0",
+        "phpunit/phpunit" : "~6.0||~7.0||~8.0",
         "orchestra/testbench": "~3.0"
     },
     "autoload": {

--- a/src/PreviewTransport.php
+++ b/src/PreviewTransport.php
@@ -3,6 +3,7 @@
 namespace Themsaid\MailPreview;
 
 use Illuminate\Support\Facades\Session;
+use Illuminate\Support\Str;
 use Swift_Mime_SimpleMessage;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Mail\Transport\Transport;
@@ -83,7 +84,7 @@ class PreviewTransport extends Transport
 
         $subject = $message->getSubject();
 
-        return $this->previewPath.'/'.str_slug($message->getDate()->getTimestamp().'_'.$to.'_'.$subject, '_');
+        return $this->previewPath.'/'.Str::slug($message->getDate()->getTimestamp().'_'.$to.'_'.$subject, '_');
     }
 
     /**


### PR DESCRIPTION
This PR adds support for Laravel 6

Changes:
* Use the Illuminate\Support\Str class and not the str_slug helper
* Allow the v6 for the used illuminate packages
* Allow phpunit 8
* Fix an error in composer.json with the dev packages.