### PR TITLE
[4.0] Add Support for Laravel 8 & Drop PHP 7.2

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest, windows-latest]
-                php: [7.4, 7.3, 7.2]
+                php: [7.4, 7.3]
                 laravel: [7.*, 8.*]
                 dependency-version: [prefer-lowest, prefer-stable]
                 include:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,11 +10,13 @@ jobs:
             matrix:
                 os: [ubuntu-latest, windows-latest]
                 php: [7.4, 7.3, 7.2]
-                laravel: [7.*]
+                laravel: [7.*, 8.*]
                 dependency-version: [prefer-lowest, prefer-stable]
                 include:
                     -   laravel: 7.*
                         testbench: 5.*
+                    -   laravel: 8.*
+                        testbench: 6.*
 
         name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 

--- a/composer.json
+++ b/composer.json
@@ -12,12 +12,12 @@
     ],
     "require": {
         "php": "^7.2.5",
-        "illuminate/support": "^7.0",
-        "illuminate/mail": "^7.0",
-        "illuminate/filesystem": "^7.0"
+        "illuminate/support": "^7.0 || ^8.0",
+        "illuminate/mail": "^7.0 || ^8.0",
+        "illuminate/filesystem": "^7. || ^8.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^5.0"
+        "orchestra/testbench": "^5.0 || ^6.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": "^7.2.5",
+        "php": "^7.3",
         "illuminate/support": "^7.0 || ^8.0",
         "illuminate/mail": "^7.0 || ^8.0",
         "illuminate/filesystem": "^7. || ^8.0"


### PR DESCRIPTION
Updating version constraints to allow the package to be installed in Laravel 8.
Also dropping support for PHP 7.2 as Laravel 8 requires at least PHP 7.3.