### PR TITLE
add 'U' to default date format to prevent issue when multiple mails s…

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,9 +120,9 @@ return [
     /**
      * Determines the date format used for the file names.
      *
-     * The default 'u' stands for microseconds.
+     * The default 'Uu' stands for seconds since Unix Epoch with microseconds.
      */
-    'filename_date_format' => 'u',
+    'filename_date_format' => 'Uu',
 ];
 
 ```

--- a/config/mail-preview.php
+++ b/config/mail-preview.php
@@ -33,7 +33,7 @@ return [
     /**
      * Determines the date format used for the file names.
      *
-     * The default 'u' stands for microseconds.
+     * The default 'Uu' stands for seconds since Unix Epoch with microseconds.
      */
-    'filename_date_format' => 'u',
+    'filename_date_format' => 'Uu',
 ];

--- a/src/PreviewMailTransport.php
+++ b/src/PreviewMailTransport.php
@@ -140,7 +140,7 @@ class PreviewMailTransport extends AbstractTransport
 
     protected function filenameDateFormat(): string
     {
-        return config('mail-preview.filename_date_format') ?? 'u';
+        return config('mail-preview.filename_date_format') ?? 'Uu';
     }
 
     public function __toString(): string


### PR DESCRIPTION
…ent in the same request

I have experienced issues when sending multiple mails to the same email address in the same request. As the default date format is 'u' it only adds the microsecond part of the timestamp to the filenames. If multiple mails are sent that span a second boundary this can result in the wrong email being chosen.

I've changed the default date format to 'Uu' so that it includes the seconds since the Unix Epoch with microseconds.

This ensures that the Controller always selects to most recently sent email.